### PR TITLE
Update README.md to fix the Discord url

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ https://github.com/gRoussac/casper-deployer/blob/master/SECURITY.md
 
 ### ❓Have questions?
 
-Go to the `#hackathon` channel [on Discord](https://discord.gg/casperblockchain)
+Go to the `#hackathon` channel [on Discord](https://discord.gg/caspernetwork)
 
 ### 🪦 Errors ?
 


### PR DESCRIPTION
The new official url is https://discord.gg/caspernetwork