### PR TITLE
Transaction UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Open http://localhost:4242/
 
 ## SDK upgrade note
 
-The app vendors SDK packs under `casper-rust-wasm-sdk/`. To refresh from a local checkout of the WASM SDK (e.g. `/opt2/casper/rustSDK` at tag `v2.2.2`):
+The app vendors SDK packs under `casper-rust-wasm-sdk/`. To refresh from a local checkout of [casper-rust-wasm-sdk](https://github.com/casper-ecosystem/casper-rust-wasm-sdk) (e.g. tag `v2.2.2`):
 
 ```shell
 rm -rf casper-rust-wasm-sdk/pkg casper-rust-wasm-sdk/pkg-nodejs

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Live (beta): [https://casper.onrender.com/](https://casper.onrender.com/)
 - Pick a network peer (localhost / testnet / mainnet / custom)
 - Query state root hash, global state, dictionary items, balances
 - Build, sign, and send **transactions** (Casper 2.x) via the NestJS RPC proxy
+- Load a previously signed transaction JSON and send it without re-signing
 
 Browser calls never talk to public nodes directly for RPC — the Nest API (`/api/deployer/*`) runs the Node WASM SDK server-side to avoid CORS.
 
@@ -106,6 +107,9 @@ Then `cd www && npm install`.
 - [x] Entity / AddressableEntity named-key + dictionary queries (Phase 2)
 - [x] Network / peers / SSE hardening (Phase 3 — NCTL `11101`/`18101`, no launcher `7777`)
 - [x] Re-enable CI + expand tests (Phase 4)
+- [x] Polish (Phase 5): Transaction UI copy, load/send signed JSON, remove speculative Test button
+
+Rollback to Casper 1.x: `git checkout v1.6`
 
 ## License / security
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Then `cd www && npm install`.
 - [x] Entity / AddressableEntity named-key + dictionary queries (Phase 2)
 - [x] Network / peers / SSE hardening (Phase 3 — NCTL `11101`/`18101`, no launcher `7777`)
 - [x] Re-enable CI + expand tests (Phase 4)
-- [x] Polish (Phase 5): Transaction UI copy, load/send signed JSON, remove speculative Test button
+- [x] Polish (Phase 5): Transaction UI copy, load/send signed JSON, drop speculative exec entirely
 
 Rollback to Casper 1.x: `git checkout v1.6`
 

--- a/www/apps/api/src/app/app.service.spec.ts
+++ b/www/apps/api/src/app/app.service.spec.ts
@@ -170,7 +170,6 @@ describe('AppService', () => {
       };
       const result = await service.putTransaction(
         signed as never,
-        false,
         'http://localhost:11101',
       );
       expect(result.transaction_hash).toBe('tx-hash-1');

--- a/www/apps/api/src/app/app.service.ts
+++ b/www/apps/api/src/app/app.service.ts
@@ -15,8 +15,6 @@ import {
   PublicKey,
   PurseIdentifier,
   Transaction,
-  getSpeculativeExecDeployOptions,
-  getSpeculativeExecTxnOptions,
 } from 'casper-rust-wasm-sdk-nodejs';
 
 @Injectable()
@@ -257,7 +255,6 @@ export class AppService {
 
   async putDeploy(
     signedDeploy: Deploy,
-    speculative = false,
     apiUrl: string,
   ): Promise<DeployReturn> {
     const sdk = this.sdkService.getCasperSDK(apiUrl);
@@ -265,37 +262,16 @@ export class AppService {
       console.error(signedDeploy);
       return;
     }
-    if (speculative) {
-      console.debug('speculative', speculative);
-      return (
-        await sdk.speculative_exec_deploy({
-          deploy: signedDeploy,
-        } as getSpeculativeExecDeployOptions)
-      ).toJson();
-    }
     return (await sdk.put_deploy(signedDeploy)).toJson();
   }
 
   async putTransaction(
     signedTransaction: Transaction,
-    speculative = false,
     apiUrl: string,
   ): Promise<TransactionReturn> {
     const sdk = this.sdkService.getCasperSDK(apiUrl);
     if (signedTransaction && !signedTransaction.verify()) {
       console.warn('transaction verify failed', signedTransaction);
-    }
-    if (speculative) {
-      console.debug('speculative transaction', speculative);
-      const result = await sdk.speculative_exec({
-        transaction: signedTransaction.toJson(),
-      } as getSpeculativeExecTxnOptions);
-      const json = result.toJson();
-      return {
-        transaction_hash:
-          json?.transaction_hash?.toString?.() || json?.transaction_hash || '',
-        ...json,
-      };
     }
     const result = await sdk.put_transaction(signedTransaction);
     const json = result.toJson();

--- a/www/apps/api/src/app/controller/deployer/deployer.controller.spec.ts
+++ b/www/apps/api/src/app/controller/deployer/deployer.controller.spec.ts
@@ -66,7 +66,7 @@ describe('DeployerController', () => {
 
   it('should put_transaction', async () => {
     const body = JSON.stringify({ Version1: {} });
-    const result = await controller.putTransaction(body, false, url);
+    const result = await controller.putTransaction(body, url);
     expect(result).toEqual({ transaction_hash: 'tx-abc' });
     expect(putTransaction).toHaveBeenCalled();
   });

--- a/www/apps/api/src/app/controller/deployer/deployer.controller.ts
+++ b/www/apps/api/src/app/controller/deployer/deployer.controller.ts
@@ -146,7 +146,6 @@ export class DeployerController {
   @Post(api_interface.Put_Deploy)
   async putDeploy(
     @Body('signedDeploy') signedDeploy: string,
-    @Body('speculative') speculative?: boolean,
     @Body('apiUrl') apiUrl?: string,
   ): Promise<DeployReturn | Error> {
     try {
@@ -156,7 +155,7 @@ export class DeployerController {
         return;
       }
       const deploy = new Deploy(signedDeployFromJson);
-      return await this.appService.putDeploy(deploy, speculative, apiUrl);
+      return await this.appService.putDeploy(deploy, apiUrl);
     } catch (error) {
       return { name: error.toString(), message: error };
     }
@@ -165,7 +164,6 @@ export class DeployerController {
   @Post(api_interface.Put_Transaction)
   async putTransaction(
     @Body('signedTransaction') signedTransaction: string,
-    @Body('speculative') speculative?: boolean,
     @Body('apiUrl') apiUrl?: string,
   ): Promise<TransactionReturn | Error> {
     try {
@@ -175,11 +173,7 @@ export class DeployerController {
         return;
       }
       const transaction = new Transaction(signedTransactionFromJson);
-      return await this.appService.putTransaction(
-        transaction,
-        speculative,
-        apiUrl,
-      );
+      return await this.appService.putTransaction(transaction, apiUrl);
     } catch (error) {
       return { name: error.toString(), message: error };
     }

--- a/www/apps/frontend-e2e/src/e2e/app.cy.ts
+++ b/www/apps/frontend-e2e/src/e2e/app.cy.ts
@@ -66,6 +66,9 @@ describe('deployer', () => {
     cy.contains('button', 'Make transaction');
     cy.contains('button', 'Sign only');
     cy.contains('button', 'Sign & Send');
+    cy.contains('button', 'Load signed JSON');
+    cy.contains('button', 'Send loaded');
+    cy.contains('button', 'Test').should('not.exist');
   });
 
   it('should have prefilled gas / TTL inputs', () => {

--- a/www/libs/data-access/deployer/src/lib/deployer.service.ts
+++ b/www/libs/data-access/deployer/src/lib/deployer.service.ts
@@ -255,11 +255,9 @@ export class DeployerService {
   putDeploy(
     signedDeploy: string,
     apiUrl?: string,
-    speculative?: boolean,
   ): Observable<DeployReturn | string> {
     let params = new HttpParams();
     apiUrl && (params = params.append('apiUrl', apiUrl));
-    speculative && (params = params.append('speculative', speculative));
     params = params.append('signedDeploy', signedDeploy);
     return this.http
       .post<DeployReturn | Error>(
@@ -277,11 +275,9 @@ export class DeployerService {
   putTransaction(
     signedTransaction: string,
     apiUrl?: string,
-    speculative?: boolean,
   ): Observable<TransactionReturn | string> {
     let params = new HttpParams();
     apiUrl && (params = params.append('apiUrl', apiUrl));
-    speculative && (params = params.append('speculative', speculative));
     params = params.append('signedTransaction', signedTransaction);
     return this.http
       .post<TransactionReturn | Error>(

--- a/www/libs/feature/deployer/src/lib/put-deploy/put-deploy.component.html
+++ b/www/libs/feature/deployer/src/lib/put-deploy/put-deploy.component.html
@@ -344,12 +344,12 @@
         />
       </div>
     </div>
-    <div class="flex items-center justify-between mb-2">
+    <div class="flex items-center justify-between mb-2 flex-wrap gap-2">
       <button
         class="flex bg-casper bg-opacity-75 hover:bg-opacity-100 text-white font-small py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-opacity-10"
         type="button"
         (click)="makeTransaction()"
-        [attr.disabled]="isMakeDeployDisabled ? true : null"
+        [attr.disabled]="isMakeTransactionDisabled ? true : null"
       >
         Make transaction
         <svg
@@ -367,34 +367,11 @@
           ></path>
         </svg>
       </button>
-      <!-- TODO Buggy on some nodes -->
-      <button
-        class="flex bg-casper bg-opacity-75 hover:bg-opacity-100 text-white font-small py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-opacity-10"
-        type="button"
-        (click)="speculativeTransaction()"
-        [attr.disabled]="true"
-      >
-        Test
-        <svg
-          class="w-6 h-6 ml-1"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          ></path>
-        </svg>
-      </button>
       <button
         class="flex bg-casper bg-opacity-75 hover:bg-opacity-100 text-white font-small py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-opacity-10"
         type="button"
         (click)="signTransaction(false)"
-        [attr.disabled]="isMakeDeployDisabled ? true : null"
+        [attr.disabled]="isMakeTransactionDisabled ? true : null"
       >
         Sign only
         <svg
@@ -416,7 +393,7 @@
         class="flex bg-casper bg-opacity-75 hover:bg-opacity-100 text-white font-small py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-opacity-10"
         type="button"
         (click)="signTransaction()"
-        [attr.disabled]="isMakeDeployDisabled ? true : null"
+        [attr.disabled]="isMakeTransactionDisabled ? true : null"
       >
         Sign & Send
         <svg
@@ -433,6 +410,28 @@
             d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"
           ></path>
         </svg>
+      </button>
+      <input
+        class="hidden"
+        #signedTxFileElt
+        type="file"
+        accept=".json,application/json"
+        (change)="onSignedTransactionFileSelected($event)"
+      />
+      <button
+        class="flex bg-casper bg-opacity-75 hover:bg-opacity-100 text-white font-small py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-opacity-10"
+        type="button"
+        (click)="signedTxFileElt.click()"
+      >
+        Load signed JSON
+      </button>
+      <button
+        class="flex bg-casper bg-opacity-75 hover:bg-opacity-100 text-white font-small py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-opacity-10"
+        type="button"
+        (click)="sendLoadedTransaction()"
+        [attr.disabled]="!loadedSignedTransaction ? true : null"
+      >
+        Send loaded
       </button>
     </div>
   </form>

--- a/www/libs/feature/deployer/src/lib/put-deploy/put-deploy.component.ts
+++ b/www/libs/feature/deployer/src/lib/put-deploy/put-deploy.component.ts
@@ -81,6 +81,7 @@ export class PutDeployComponent implements AfterViewInit, OnDestroy {
   sessionHash!: string;
   entryPoint!: string;
   file_name!: string;
+  loadedSignedTransaction?: string;
   version!: string;
   animate!: boolean;
   stateRootHash?: string;
@@ -308,26 +309,60 @@ export class PutDeployComponent implements AfterViewInit, OnDestroy {
     return this.signTransaction(sendDeploy);
   }
 
-  async speculativeTransaction() {
-    const speculative = true,
-      sendTransaction = false;
-    this.makeTransaction();
-    const signedTransaction = await this.signTransaction(sendTransaction);
-    signedTransaction &&
-      this.deployerService
-        .putTransaction(signedTransaction, this.apiUrl, speculative)
-        .subscribe((result: string | TransactionReturn) => {
-          result &&
-            this.resultService.setResult<string>(
-              'Speculative Transaction Hash',
-              (result as TransactionReturn).transaction_hash,
-            );
-        });
+  async onSignedTransactionFileSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.item(0);
+    if (!file) {
+      return;
+    }
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      const signed = new Transaction(parsed);
+      if (signed && !signed.verify()) {
+        this.toastr.warning(
+          signed.toString(),
+          'Loaded transaction verify warning',
+        );
+      }
+      this.loadedSignedTransaction = JSON.stringify(signed.toJson() || parsed);
+      this.resultService.setResult<Transaction>(
+        'Loaded Signed Transaction',
+        signed.toJson() || parsed,
+      );
+      this.changeDetectorRef.markForCheck();
+    } catch (err) {
+      console.error(err);
+      this.toastr.error(String(err), 'Invalid signed transaction JSON');
+      this.loadedSignedTransaction = undefined;
+    }
+    (event.target as HTMLInputElement).value = '';
   }
 
-  /** @deprecated Use speculativeTransaction */
-  async speculativeDeploy() {
-    return this.speculativeTransaction();
+  sendLoadedTransaction() {
+    if (!this.loadedSignedTransaction) {
+      return;
+    }
+    this.deployerService
+      .putTransaction(this.loadedSignedTransaction, this.apiUrl)
+      .subscribe((result: string | TransactionReturn) => {
+        const transaction_hash = (result as TransactionReturn).transaction_hash;
+        transaction_hash &&
+          this.resultService.setResult<string>(
+            'Transaction Hash',
+            transaction_hash || (result as string),
+          );
+        if (transaction_hash) {
+          this.deployerService.setState({
+            transaction_hash,
+            deploy_hash: transaction_hash,
+          });
+          this.watcherService.watchTransaction(transaction_hash, this.apiUrl);
+          this.storageService.setState({
+            transaction_hash,
+            deploy_hash: transaction_hash,
+          });
+        }
+      });
   }
 
   resetFirstForm($event: Event) {
@@ -363,8 +398,13 @@ export class PutDeployComponent implements AfterViewInit, OnDestroy {
     this.resultService.copyClipboard(value);
   }
 
-  get isMakeDeployDisabled() {
+  get isMakeTransactionDisabled() {
     return !this.isFormValid();
+  }
+
+  /** @deprecated Use isMakeTransactionDisabled */
+  get isMakeDeployDisabled() {
+    return this.isMakeTransactionDisabled;
   }
 
   get isSessionNameDisabled(): boolean {


### PR DESCRIPTION
## Summary
- Remove dead speculative **Test** button (never verified on 2.x RPC)
- Add **Load signed JSON** + **Send loaded** for Sign-only → file → submit flow
- README Phase 5 checklist + `v1.6` rollback note

## Test plan
- [x] `nx run deployer:test`
- [x] `nx run frontend-e2e:e2e` (mocked)
- [ ] Manual: Sign only → save JSON → Load signed JSON → Send loaded


Made with [Cursor](https://cursor.com)