### PR TITLE
Stabilize peers select; hide localhost when hosted

### DIFF
--- a/www/apps/frontend-e2e/src/e2e/app.cy.ts
+++ b/www/apps/frontend-e2e/src/e2e/app.cy.ts
@@ -8,11 +8,16 @@ describe('deployer', () => {
     cy.intercept('GET', /\/api\/deployer\/status.*/, {
       body: JSON.stringify('status'),
     }).as('getStatus');
-    cy.intercept('GET', /\/api\/deployer\/peers.*/, {
-      body: [
-        { node_id: 'n1', address: 'http://localhost:11101' },
-        { node_id: 'n2', address: 'http://localhost:11102' },
-      ],
+    cy.intercept('GET', /\/api\/deployer\/peers.*/, (req) => {
+      const apiUrl = String(req.query.apiUrl || '');
+      // Gossip peer URLs must never be used as the peers RPC source.
+      expect(apiUrl).to.not.match(/:35000/);
+      req.reply({
+        body: [
+          { node_id: 'tls:a', address: 'http://88.99.3.132:35000' },
+          { node_id: 'tls:b', address: 'http://65.109.35.234:35000' },
+        ],
+      });
     }).as('getPeers');
     cy.intercept('GET', /\/api\/deployer\/getStateRootHash.*/, {
       body: JSON.stringify(stateRootHash),
@@ -65,18 +70,49 @@ describe('deployer', () => {
     cy.wait('@getPeers');
     cy.get('select')
       .first()
-      .find('optgroup[label="peers / custom"] option')
+      .find('optgroup[label="peers / custom (gossip)"] option')
       .should('have.length', 2)
       .then(($opts) => {
         const values = [...$opts].map((o) => o.value);
         const texts = [...$opts].map((o) => (o.textContent || '').trim());
         expect(values).to.deep.eq([
-          'http://localhost:11101',
-          'http://localhost:11102',
+          'http://88.99.3.132:35000',
+          'http://65.109.35.234:35000',
         ]);
         expect(texts).to.deep.eq(values);
         expect(new Set(values).size).to.eq(values.length);
       });
+  });
+
+  it('should keep peers list stable when selecting a gossip peer', () => {
+    cy.wait('@getPeers');
+    cy.get('select')
+      .first()
+      .find('optgroup[label="peers / custom (gossip)"] option')
+      .should('have.length', 2);
+
+    cy.get('select')
+      .first()
+      .select('http://88.99.3.132:35000', { force: true });
+
+    cy.get('input[name="apiUrl"]')
+      .invoke('val')
+      .should('eq', 'http://88.99.3.132:35000');
+
+    // Gossip peer must not move into presets.
+    cy.get('select')
+      .first()
+      .find('optgroup[label="presets"] option')
+      .then(($opts) => {
+        const texts = [...$opts].map((o) => (o.textContent || '').trim());
+        expect(texts).to.not.include('http://88.99.3.132:35000');
+      });
+
+    // Peers optgroup stays populated (no refetch from :35000).
+    cy.get('select')
+      .first()
+      .find('optgroup[label="peers / custom (gossip)"] option')
+      .should('have.length', 2);
   });
 
   it('should show empty peers group when API returns no peers', () => {
@@ -87,12 +123,12 @@ describe('deployer', () => {
     cy.wait('@getPeersEmpty');
     cy.get('select')
       .first()
-      .find('optgroup[label="peers / custom"] option')
+      .find('optgroup[label="peers / custom (gossip)"] option')
       .should('have.length', 0);
     cy.get('select')
       .first()
       .find('optgroup[label="presets"] option')
-      .should('have.length.at.least', 3);
+      .should('have.length.at.least', 2);
   });
 
   it('should show Transaction UI (not Deploy-only)', () => {

--- a/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.html
+++ b/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.html
@@ -28,13 +28,16 @@
         >
           <optgroup label="presets">
             @for (default of defaults; track default; let i = $index) {
-              <option [attr.selected]="apiUrl === default ? true : null">
+              <option
+                [value]="default"
+                [attr.selected]="apiUrl === default ? true : null"
+              >
                 {{ default }}
               </option>
             }
           </optgroup>
 
-          <optgroup label="peers / custom">
+          <optgroup label="peers / custom (gossip)">
             @for (peer of peers; track trackByFn(i, peer); let i = $index) {
               <option [value]="peer.address">
                 {{ peer.address }}

--- a/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.spec.ts
+++ b/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.spec.ts
@@ -16,14 +16,18 @@ describe('StateRootHashComponent', () => {
   let component: StateRootHashComponent;
   let fixture: ComponentFixture<StateRootHashComponent>;
   let getPeers: jest.Mock;
+  let getStatus: jest.Mock;
+  let getStateRootHash: jest.Mock;
 
   const peers: Peer[] = [
-    { address: 'http://localhost:11101', node_id: 'n0' },
-    { address: 'http://localhost:11102', node_id: 'n1' },
+    { address: 'http://88.99.3.132:35000', node_id: 'tls:a' },
+    { address: 'http://65.109.35.234:35000', node_id: 'tls:b' },
   ];
 
   beforeEach(async () => {
     getPeers = jest.fn().mockReturnValue(of(peers));
+    getStatus = jest.fn().mockReturnValue(of('status'));
+    getStateRootHash = jest.fn().mockReturnValue(of('srh'));
 
     await TestBed.configureTestingModule({
       imports: [StateRootHashComponent, HttpClientModule],
@@ -47,8 +51,8 @@ describe('StateRootHashComponent', () => {
           useValue: {
             setState: jest.fn(),
             getPeers,
-            getStatus: () => of('status'),
-            getStateRootHash: () => of('srh'),
+            getStatus,
+            getStateRootHash,
           },
         },
         {
@@ -73,51 +77,68 @@ describe('StateRootHashComponent', () => {
   });
 
   it('should render peer options with address as value', () => {
-    component.apiUrl = 'http://localhost:11101';
+    component.apiUrl = config['default_node_testnet'];
+    (component as unknown as { peersSourceUrl: string }).peersSourceUrl =
+      config['default_node_testnet'];
     component.getPeers();
     fixture.detectChanges();
 
     const options = fixture.nativeElement.querySelectorAll(
-      'optgroup[label="peers / custom"] option',
+      'optgroup[label="peers / custom (gossip)"] option',
     ) as NodeListOf<HTMLOptionElement>;
     expect(options.length).toBe(2);
-    expect(options[0].value).toBe('http://localhost:11101');
-    expect(options[0].textContent?.trim()).toBe('http://localhost:11101');
-    expect(options[1].value).toBe('http://localhost:11102');
+    expect(options[0].value).toBe('http://88.99.3.132:35000');
+    expect(options[0].textContent?.trim()).toBe('http://88.99.3.132:35000');
   });
 
   it('should leave peers optgroup empty when API returns no peers', () => {
     getPeers.mockReturnValue(of([]));
-    component.apiUrl = 'https://node.testnet.casper.network';
+    component.apiUrl = config['default_node_testnet'];
+    (component as unknown as { peersSourceUrl: string }).peersSourceUrl =
+      config['default_node_testnet'];
     component.getPeers();
     fixture.detectChanges();
 
     expect(component.peers).toEqual([]);
     const peerOptions = fixture.nativeElement.querySelectorAll(
-      'optgroup[label="peers / custom"] option',
+      'optgroup[label="peers / custom (gossip)"] option',
     );
     expect(peerOptions.length).toBe(0);
-
-    const presetTexts = [
-      ...(fixture.nativeElement.querySelectorAll(
-        'optgroup[label="presets"] option',
-      ) as NodeListOf<HTMLOptionElement>),
-    ].map((o) => o.textContent?.trim());
-    expect(presetTexts).toEqual(
-      expect.arrayContaining([
-        config['default_node_localhost'],
-        config['default_node_testnet'],
-        config['default_node_mainnet'],
-      ]),
-    );
   });
 
-  it('should load peers from DeployerService for the selected apiUrl', () => {
-    component.apiUrl = 'http://localhost:11101';
+  it('should load peers from the peers source RPC, not a gossip peer URL', () => {
+    component.apiUrl = config['default_node_testnet'];
+    (component as unknown as { peersSourceUrl: string }).peersSourceUrl =
+      config['default_node_testnet'];
     component.getPeers();
+
+    expect(getPeers).toHaveBeenCalledWith(config['default_node_testnet']);
+    expect(component.peers).toEqual(peers);
+  });
+
+  it('should not promote gossip peers into presets or refetch peers from them', () => {
+    component.apiUrl = config['default_node_testnet'];
+    (component as unknown as { peersSourceUrl: string }).peersSourceUrl =
+      config['default_node_testnet'];
+    component.peers = peers;
+    component.apiUrlElt = { value: '' } as HTMLInputElement;
+    const presetsBefore = [...component.defaults];
+    getPeers.mockClear();
+    getStatus.mockClear();
+    getStateRootHash.mockClear();
+
+    const event = {
+      target: { value: peers[0].address },
+    } as unknown as Event;
+    component.selectApiUrl(event);
     fixture.detectChanges();
 
-    expect(getPeers).toHaveBeenCalledWith('http://localhost:11101');
+    expect(component.apiUrl).toBe(peers[0].address);
+    expect(component.defaults).toEqual(presetsBefore);
+    expect(component.defaults).not.toContain(peers[0].address);
+    expect(getPeers).not.toHaveBeenCalled();
     expect(component.peers).toEqual(peers);
+    expect(getStatus).not.toHaveBeenCalled();
+    expect(getStateRootHash).not.toHaveBeenCalled();
   });
 });

--- a/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.ts
+++ b/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.ts
@@ -32,7 +32,10 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
   private getStatusSubscription!: Subscription;
   private window!: (Window & typeof globalThis) | null;
 
-  peers!: Peer[];
+  /** RPC used for info_get_peers — never a gossip :35000 peer URL. */
+  private peersSourceUrl!: string;
+
+  peers: Peer[] = [];
   status = '';
   apiUrl!: string;
   @ViewChild('apiUrlElt') apiUrlElt!: HTMLInputElement;
@@ -48,11 +51,7 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
     private readonly storageService: StorageService,
   ) {
     this.window = this.document.defaultView;
-    this.defaults = [
-      this.config['default_node_localhost'],
-      this.config['default_node_testnet'],
-      this.config['default_node_mainnet'],
-    ];
+    this.defaults = this.buildDefaults();
   }
 
   ngAfterViewInit(): void {
@@ -60,22 +59,31 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
       const apiUrl = this.storageService.get('apiUrl');
       if (apiUrl) {
         this.apiUrl = apiUrl;
-        if (!this.defaults.includes(this.apiUrl)) {
+        if (
+          !this.defaults.includes(this.apiUrl) &&
+          !this.isGossipPeerUrl(this.apiUrl)
+        ) {
           this.defaults.push(this.apiUrl);
         }
         this.deployerService.setState({ apiUrl });
         this.syncChainName(apiUrl);
       } else {
         const currentHost = this.window?.location.hostname;
-        if (currentHost && this.defaults[0].includes(currentHost)) {
-          this.apiUrl = this.defaults[0];
+        const localhost = this.config['default_node_localhost'];
+        if (
+          this.isLocalBrowserHost() &&
+          currentHost &&
+          localhost.includes(currentHost)
+        ) {
+          this.apiUrl = localhost;
         } else {
-          this.apiUrl = this.defaults[1]; // testnet
+          this.apiUrl = this.config['default_node_testnet'];
         }
         this.routeurHubService.setHubState({ apiUrl: this.apiUrl });
         this.deployerService.setState({ apiUrl: this.apiUrl });
         this.syncChainName(this.apiUrl);
       }
+      this.peersSourceUrl = this.peersSourceFor(this.apiUrl);
       this.getPeers();
     });
   }
@@ -92,9 +100,8 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
     if (!apiUrl) {
       return;
     }
-    let url: URL;
     try {
-      url = new URL(apiUrl);
+      const url = new URL(apiUrl);
       apiUrl = (url.origin + url.pathname).replace(/\/$/, '');
     } catch (error) {
       console.error(error);
@@ -104,10 +111,29 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
     this.deployerService.setState({ apiUrl: this.apiUrl });
     this.routeurHubService.setHubState({ apiUrl: this.apiUrl });
     this.syncChainName(this.apiUrl);
-    if (!this.defaults.includes(this.apiUrl)) {
+
+    // Gossip peers stay in the peers optgroup — do not pollute presets.
+    if (
+      !this.defaults.includes(this.apiUrl) &&
+      !this.isGossipPeerUrl(this.apiUrl)
+    ) {
       this.defaults.push(this.apiUrl);
     }
-    this.getPeers();
+
+    // Keep peers list tied to a real JSON-RPC endpoint (testnet/mainnet/NCTL).
+    const nextPeersSource = this.peersSourceFor(this.apiUrl);
+    const peersSourceChanged = nextPeersSource !== this.peersSourceUrl;
+    this.peersSourceUrl = nextPeersSource;
+
+    if (peersSourceChanged || !this.peers?.length) {
+      this.getPeers();
+    } else if (!this.isGossipPeerUrl(this.apiUrl)) {
+      this.getStatus();
+      this.getStateRootHash();
+    } else {
+      this.status = '';
+      this.changeDetectorRef.markForCheck();
+    }
     this.routeurHubService.refreshPurse();
   }
 
@@ -146,13 +172,18 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
   }
 
   getPeers(): void {
-    this.apiUrl &&
+    const url = this.peersSourceUrl || this.apiUrl;
+    url &&
       (this.getPeersSubscription = this.deployerService
-        .getPeers(this.apiUrl)
+        .getPeers(url)
         .subscribe((peersResult) => {
-          this.peers = peersResult as Peer[];
-          this.getStatus();
-          this.getStateRootHash();
+          this.peers = Array.isArray(peersResult) ? peersResult : [];
+          if (!this.isGossipPeerUrl(this.apiUrl)) {
+            this.getStatus();
+            this.getStateRootHash();
+          } else {
+            this.status = '';
+          }
           this.getPeersSubscription.unsubscribe();
           this.changeDetectorRef.markForCheck();
         }));
@@ -174,5 +205,50 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
     this.resultService.copyClipboard(value);
   }
 
-  trackByFn = (index: number, item: Peer): string => item.node_id;
+  trackByFn = (_index: number, item: Peer): string =>
+    `${item.node_id}|${item.address}`;
+
+  /** Local docker/dev stack in the browser — keep localhost preset. */
+  private isLocalBrowserHost(): boolean {
+    const host = this.window?.location.hostname || '';
+    return host === 'localhost' || host === '127.0.0.1';
+  }
+
+  /**
+   * Hosted sites (e.g. casper-deployer.interchouette.net): omit localhost.
+   * Local browser host: include NCTL localhost preset.
+   */
+  private buildDefaults(): string[] {
+    const defaults = [
+      this.config['default_node_testnet'],
+      this.config['default_node_mainnet'],
+    ];
+    if (this.isLocalBrowserHost()) {
+      defaults.unshift(this.config['default_node_localhost']);
+    }
+    return defaults;
+  }
+
+  /** Casper gossip/network peers from info_get_peers are typically :35000. */
+  private isGossipPeerUrl(apiUrl: string): boolean {
+    try {
+      const url = new URL(
+        apiUrl.includes('://') ? apiUrl : `http://${apiUrl}`,
+      );
+      return url.port === '35000';
+    } catch {
+      return /:35000(?:\/|$)/.test(apiUrl);
+    }
+  }
+
+  private peersSourceFor(apiUrl: string): string {
+    if (this.isGossipPeerUrl(apiUrl)) {
+      return (
+        this.peersSourceUrl ||
+        this.config['default_node_testnet'] ||
+        apiUrl
+      );
+    }
+    return apiUrl;
+  }
 }


### PR DESCRIPTION
## Summary
- Selecting a gossip peer (`:35000`) was promoting it into **presets** and re-calling `getPeers` against that non-RPC URL → empty/broken peers list + `fetch failed` on state root hash.
- Keep peers sourced from the last real RPC (testnet/mainnet/NCTL). Gossip picks update the Node field only and leave the peers optgroup intact.
- Hosted site (non-localhost hostname): omit `http://localhost:11101` preset. Local browser host / docker-dev stack: keep it.
- Cypress now stubs gossip-style peers and asserts select stability; unit test covers the same.

## Test plan
- [x] `nx run deployer:test --testPathPattern=state-root-hash`
- [ ] CI Cypress green
- [ ] On https://casper-deployer.interchouette.net/: no localhost preset; pick a peer → peers list stays filled; peer not added under presets
- [ ] Locally on localhost:4242: localhost preset still present


Made with [Cursor](https://cursor.com)