### PR TITLE
Stop localhost:11101 flash on hosted sites

### DIFF
--- a/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.html
+++ b/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.html
@@ -15,8 +15,8 @@
           name="apiUrl"
           #apiUrlElt
           type="url"
-          [placeholder]="'ex: ' + config['default_node_localhost']"
-          [value]="apiUrl || config['default_node_localhost']"
+          [placeholder]="'ex: ' + (defaults[0] || config['default_node_testnet'])"
+          [value]="apiUrl"
           (keyup.enter)="getStateRootHash()"
           (change)="selectApiUrl($event)"
         />

--- a/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.spec.ts
+++ b/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.spec.ts
@@ -142,3 +142,67 @@ describe('StateRootHashComponent', () => {
     expect(getStateRootHash).not.toHaveBeenCalled();
   });
 });
+
+describe('StateRootHashComponent hosted browser', () => {
+  it('should default to testnet with no localhost flash or preset', async () => {
+    jest
+      .spyOn(
+        StateRootHashComponent.prototype as unknown as {
+          isLocalBrowserHost: () => boolean;
+        },
+        'isLocalBrowserHost',
+      )
+      .mockReturnValue(false);
+
+    const getPeers = jest.fn().mockReturnValue(of([]));
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [StateRootHashComponent, HttpClientModule],
+      providers: [
+        {
+          provide: ResultService,
+          useValue: { setResult: jest.fn(), copyClipboard: jest.fn() },
+        },
+        RouteurHubService,
+        { provide: ENV_CONFIG, useValue: config },
+        { provide: HIGHLIGHT_WEBWORKER_FACTORY, useValue: jest.fn() },
+        { provide: TOASTER_TOKEN, useValue: {} },
+        {
+          provide: DeployerService,
+          useValue: {
+            setState: jest.fn(),
+            getPeers,
+            getStatus: () => of('status'),
+            getStateRootHash: () => of('srh'),
+          },
+        },
+        {
+          provide: StorageService,
+          useValue: {
+            // Stale local value must not win on a hosted site.
+            get: jest.fn().mockReturnValue(config['default_node_localhost']),
+            set: jest.fn(),
+            setState: jest.fn(),
+          },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(StateRootHashComponent);
+    const component = fixture.componentInstance;
+
+    // Before detectChanges / AfterViewInit — first paint value.
+    expect(component.apiUrl).toBe(config['default_node_testnet']);
+    expect(component.defaults).not.toContain(config['default_node_localhost']);
+    expect(component.defaults[0]).toBe(config['default_node_testnet']);
+
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector(
+      'input[name="apiUrl"]',
+    ) as HTMLInputElement;
+    expect(input.value).toBe(config['default_node_testnet']);
+    expect(input.value).not.toContain('localhost');
+  });
+});

--- a/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.ts
+++ b/www/libs/feature/deployer/src/lib/state-root-hash/state-root-hash.component.ts
@@ -37,6 +37,7 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
 
   peers: Peer[] = [];
   status = '';
+  /** Set in the constructor so the first paint never flashes localhost on hosted sites. */
   apiUrl!: string;
   @ViewChild('apiUrlElt') apiUrlElt!: HTMLInputElement;
   defaults!: string[];
@@ -52,39 +53,24 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
   ) {
     this.window = this.document.defaultView;
     this.defaults = this.buildDefaults();
+    this.apiUrl = this.resolveInitialApiUrl();
+    this.peersSourceUrl = this.peersSourceFor(this.apiUrl);
+    if (
+      !this.defaults.includes(this.apiUrl) &&
+      !this.isGossipPeerUrl(this.apiUrl)
+    ) {
+      this.defaults.push(this.apiUrl);
+    }
   }
 
   ngAfterViewInit(): void {
+    // apiUrl is already correct from the constructor — only wire hub state + peers.
     setTimeout(() => {
-      const apiUrl = this.storageService.get('apiUrl');
-      if (apiUrl) {
-        this.apiUrl = apiUrl;
-        if (
-          !this.defaults.includes(this.apiUrl) &&
-          !this.isGossipPeerUrl(this.apiUrl)
-        ) {
-          this.defaults.push(this.apiUrl);
-        }
-        this.deployerService.setState({ apiUrl });
-        this.syncChainName(apiUrl);
-      } else {
-        const currentHost = this.window?.location.hostname;
-        const localhost = this.config['default_node_localhost'];
-        if (
-          this.isLocalBrowserHost() &&
-          currentHost &&
-          localhost.includes(currentHost)
-        ) {
-          this.apiUrl = localhost;
-        } else {
-          this.apiUrl = this.config['default_node_testnet'];
-        }
-        this.routeurHubService.setHubState({ apiUrl: this.apiUrl });
-        this.deployerService.setState({ apiUrl: this.apiUrl });
-        this.syncChainName(this.apiUrl);
-      }
-      this.peersSourceUrl = this.peersSourceFor(this.apiUrl);
+      this.deployerService.setState({ apiUrl: this.apiUrl });
+      this.routeurHubService.setHubState({ apiUrl: this.apiUrl });
+      this.syncChainName(this.apiUrl);
       this.getPeers();
+      this.changeDetectorRef.markForCheck();
     });
   }
 
@@ -227,6 +213,35 @@ export class StateRootHashComponent implements OnDestroy, AfterViewInit {
       defaults.unshift(this.config['default_node_localhost']);
     }
     return defaults;
+  }
+
+  private preferredDefaultApiUrl(): string {
+    return this.isLocalBrowserHost()
+      ? this.config['default_node_localhost']
+      : this.config['default_node_testnet'];
+  }
+
+  /** Ignore stored localhost when the UI does not offer that preset. */
+  private isUsableStoredApiUrl(apiUrl: string): boolean {
+    if (this.isLocalBrowserHost()) {
+      return true;
+    }
+    const localhost = this.config['default_node_localhost'];
+    if (
+      apiUrl === localhost ||
+      /https?:\/\/(localhost|127\.0\.0\.1):1110[1-5]\b/.test(apiUrl)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private resolveInitialApiUrl(): string {
+    const stored = this.storageService.get('apiUrl');
+    if (stored && this.isUsableStoredApiUrl(stored)) {
+      return stored;
+    }
+    return this.preferredDefaultApiUrl();
   }
 
   /** Casper gossip/network peers from info_get_peers are typically :35000. */


### PR DESCRIPTION
## Summary
- Hosted pages briefly showed `http://localhost:11101` because the input used `apiUrl || config.default_node_localhost` before `ngAfterViewInit` set testnet.
- Resolve the initial `apiUrl` in the constructor (testnet when not on localhost; ignore stale stored localhost).
- Template binds `[value]="apiUrl"` and placeholder uses the first visible preset.

## Test plan
- [x] Unit: hosted browser defaults to testnet before first detectChanges
- [ ] After deploy: hard-refresh https://casper-deployer.interchouette.net/ — Node field should open on testnet with no localhost flicker
- [ ] Localhost:4242 still starts on localhost preset


Made with [Cursor](https://cursor.com)