### PR TITLE
Redeploy Render after Docker Hub image push

### DIFF
--- a/.github/workflows/docker-build-push-dev.yml
+++ b/.github/workflows/docker-build-push-dev.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-push-dev:
-    name: Build and Push Docker Image :dev
+    name: Build and Push Docker Image :dev and :latest
     runs-on: ubuntu-latest
 
     steps:
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image :dev
+      - name: Build Docker image :dev and :latest
         run: make docker-build-dev
 
       - name: Log in to Docker Hub
@@ -34,7 +34,22 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push :dev to Docker Hub (interchouette + gregoshop mirror)
+      - name: Push :dev and :latest to Docker Hub (interchouette + gregoshop mirror)
         run: make docker-push-dev-hub
         env:
           CI: "1"
+
+      # Render does not watch Hub for new digests — call the service Deploy Hook
+      # after a successful push so it pulls interchouette/casper-deployer:latest.
+      - name: Trigger Render redeploy
+        env:
+          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "${RENDER_DEPLOY_HOOK}" ]; then
+            echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
+            exit 0
+          fi
+          echo "Triggering Render deploy hook…"
+          curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
+          echo
+          echo "Render deploy requested"

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ APP_VERSION ?= 2.2.2
 
 help:
 	@echo "Casper Deployer Docker targets"
-	@echo "  make docker-build-dev     Build and tag :dev (Hub + gregoshop mirror)"
-	@echo "  make docker-push-dev-hub  Push :dev to Docker Hub"
-	@echo "  make docker-push-dev      Local interactive push (:dev)"
+	@echo "  make docker-build-dev     Build and tag :dev and :latest (Hub + gregoshop mirror)"
+	@echo "  make docker-push-dev-hub  Push :dev and :latest to Docker Hub"
+	@echo "  make docker-push-dev      Local interactive push (:dev + :latest)"
 	@echo "  make docker-build         Build :$(TAG) and :$(APP_VERSION)"
 	@echo "  make docker-push-release-hub  Push :$(APP_VERSION) and :latest"
 	@echo "Overrides: HUB_IMAGE=$(HUB_IMAGE) HUB_MIRROR_IMAGE=$(HUB_MIRROR_IMAGE) APP_VERSION=$(APP_VERSION) TAG=$(TAG)"
@@ -36,14 +36,19 @@ docker-build:
 docker-build-dev:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build \
 		-t casper-deployer:dev \
+		-t casper-deployer:latest \
 		-t $(HUB_IMAGE):dev \
+		-t $(HUB_IMAGE):latest \
 		-t $(HUB_MIRROR_IMAGE):dev \
+		-t $(HUB_MIRROR_IMAGE):latest \
 		-f $(DOCKERFILE) \
 		.
 
 docker-push-dev-hub:
 	docker push $(HUB_IMAGE):dev
+	docker push $(HUB_IMAGE):latest
 	docker push $(HUB_MIRROR_IMAGE):dev
+	docker push $(HUB_MIRROR_IMAGE):latest
 
 docker-push-dev:
 	@if [ "$${CI:-0}" = "1" ]; then \

--- a/README.md
+++ b/README.md
@@ -91,9 +91,16 @@ Published images (Docker Hub):
 
 ```shell
 docker pull interchouette/casper-deployer:dev
+# or
+docker pull interchouette/casper-deployer:latest
 ```
 
-CI pushes `:dev` on `workflow_dispatch` and on pushes to `dev` that touch the image inputs (see `.github/workflows/docker-build-push-dev.yml`). Requires repo secrets `DOCKER_USERNAME` / `DOCKER_PASSWORD` (same as other Interchouette images).
+CI (`.github/workflows/docker-build-push-dev.yml`) on `workflow_dispatch` and on pushes to `dev` that touch image inputs:
+
+1. Builds and pushes Hub `:dev` **and** `:latest` (needs `DOCKER_USERNAME` / `DOCKER_PASSWORD`)
+2. Optionally triggers a Render redeploy via secret `RENDER_DEPLOY_HOOK` (Deploy Hook URL from the Render service → Settings → Deploy Hook). Without that secret, Hub updates but Render keeps the old container until a manual deploy.
+
+Render image deploys: no app env vars required (Render injects `PORT`). Point the service at `interchouette/casper-deployer:latest`.
 
 Open http://localhost:4242/
 


### PR DESCRIPTION
## Summary
- After CI pushes `interchouette/casper-deployer:dev` and `:latest`, curl the Render **Deploy Hook** so the hosted service pulls the new image (Hub updates alone do not redeploy Render).
- Makefile/`docker-build-dev` now tags and pushes `:latest` alongside `:dev` (matches Render’s image tag).
- Skips the hook cleanly if `RENDER_DEPLOY_HOOK` is unset.

## Setup
1. Render service → **Settings** → **Deploy Hook** → copy URL  
2. GitHub repo → **Settings** → **Secrets** → add `RENDER_DEPLOY_HOOK`  
3. Merge this PR (or run **CI/CD Image dev** manually) and confirm Render starts a deploy

## Test plan
- [ ] Add `RENDER_DEPLOY_HOOK` secret
- [ ] Run workflow_dispatch **CI/CD Image dev** (or push a path that triggers it)
- [ ] Confirm Hub `:latest` updates and Render shows a new deploy


Made with [Cursor](https://cursor.com)