### PR TITLE
Stop mirroring Docker Hub images to gregoshop

### DIFF
--- a/.github/workflows/docker-build-push-dev.yml
+++ b/.github/workflows/docker-build-push-dev.yml
@@ -34,7 +34,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push :dev and :latest to Docker Hub (interchouette + gregoshop mirror)
+      - name: Push :dev and :latest to Docker Hub (interchouette)
         run: make docker-push-dev-hub
         env:
           CI: "1"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ DOCKERFILE ?= docker/Dockerfile
 DOCKER_BUILDKIT ?= 1
 
 HUB_IMAGE ?= interchouette/casper-deployer
-HUB_MIRROR_IMAGE ?= gregoshop/casper-deployer
 APP_IMAGE ?= $(HUB_IMAGE)
 
 TAG ?= latest
@@ -17,12 +16,12 @@ APP_VERSION ?= 2.2.2
 
 help:
 	@echo "Casper Deployer Docker targets"
-	@echo "  make docker-build-dev     Build and tag :dev and :latest (Hub + gregoshop mirror)"
+	@echo "  make docker-build-dev     Build and tag :dev and :latest"
 	@echo "  make docker-push-dev-hub  Push :dev and :latest to Docker Hub"
 	@echo "  make docker-push-dev      Local interactive push (:dev + :latest)"
 	@echo "  make docker-build         Build :$(TAG) and :$(APP_VERSION)"
 	@echo "  make docker-push-release-hub  Push :$(APP_VERSION) and :latest"
-	@echo "Overrides: HUB_IMAGE=$(HUB_IMAGE) HUB_MIRROR_IMAGE=$(HUB_MIRROR_IMAGE) APP_VERSION=$(APP_VERSION) TAG=$(TAG)"
+	@echo "Overrides: HUB_IMAGE=$(HUB_IMAGE) APP_VERSION=$(APP_VERSION) TAG=$(TAG)"
 
 docker-build:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build \
@@ -39,16 +38,12 @@ docker-build-dev:
 		-t casper-deployer:latest \
 		-t $(HUB_IMAGE):dev \
 		-t $(HUB_IMAGE):latest \
-		-t $(HUB_MIRROR_IMAGE):dev \
-		-t $(HUB_MIRROR_IMAGE):latest \
 		-f $(DOCKERFILE) \
 		.
 
 docker-push-dev-hub:
 	docker push $(HUB_IMAGE):dev
 	docker push $(HUB_IMAGE):latest
-	docker push $(HUB_MIRROR_IMAGE):dev
-	docker push $(HUB_MIRROR_IMAGE):latest
 
 docker-push-dev:
 	@if [ "$${CI:-0}" = "1" ]; then \
@@ -60,10 +55,6 @@ docker-push-dev:
 docker-push-release-hub:
 	docker push $(HUB_IMAGE):$(APP_VERSION)
 	docker push $(HUB_IMAGE):latest
-	docker tag $(HUB_IMAGE):$(APP_VERSION) $(HUB_MIRROR_IMAGE):$(APP_VERSION)
-	docker tag $(HUB_IMAGE):latest $(HUB_MIRROR_IMAGE):latest
-	docker push $(HUB_MIRROR_IMAGE):$(APP_VERSION)
-	docker push $(HUB_MIRROR_IMAGE):latest
 
 docker-push-release: docker-push-release-hub
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,6 @@ docker run --rm -p 4242:4242 -e PORT=4242 interchouette/casper-deployer:dev
 Published images (Docker Hub):
 
 - [`interchouette/casper-deployer`](https://hub.docker.com/r/interchouette/casper-deployer) (`:dev`, version tags, `:latest`)
-- mirror: [`gregoshop/casper-deployer`](https://hub.docker.com/r/gregoshop/casper-deployer)
 
 ```shell
 docker pull interchouette/casper-deployer:dev
@@ -100,7 +99,7 @@ docker pull interchouette/casper-deployer:latest
 
 CI (`.github/workflows/docker-build-push-dev.yml`) on `workflow_dispatch` and on pushes to `dev` that touch image inputs:
 
-1. Builds and pushes Hub `:dev` **and** `:latest` (needs `DOCKER_USERNAME` / `DOCKER_PASSWORD`)
+1. Builds and pushes Hub `:dev` **and** `:latest` (needs `DOCKER_USERNAME` / `DOCKER_PASSWORD` for `interchouette`)
 2. Optionally triggers a Render redeploy via secret `RENDER_DEPLOY_HOOK` (Deploy Hook URL from the Render service → Settings → Deploy Hook). Without that secret, Hub updates but Render keeps the old container until a manual deploy.
 
 Render image deploys: no app env vars required (Render injects `PORT`). Point the service at `interchouette/casper-deployer:latest`.


### PR DESCRIPTION
## Summary
- Drop `gregoshop/casper-deployer` tagging and push from Makefile `docker-build-dev` / `docker-push-*-hub`
- Keep CI Docker Hub login via `DOCKER_USERNAME` / `DOCKER_PASSWORD` for `interchouette/casper-deployer` only
- Update docs to remove the gregoshop mirror reference

## Test plan
- [ ] Confirm workflow still uses `secrets.DOCKER_USERNAME` / `DOCKER_PASSWORD`
- [ ] After merge, run `CI/CD Image dev` (or push an image-path change) and verify only `interchouette/casper-deployer:{dev,latest}` is pushed
- [ ] Confirm no push attempt to `gregoshop/casper-deployer`


Made with [Cursor](https://cursor.com)